### PR TITLE
fix: Prevents auctions with bugged timestamps at HomePage

### DIFF
--- a/apps/web/src/data/subgraph/requests/homepageQuery.ts
+++ b/apps/web/src/data/subgraph/requests/homepageQuery.ts
@@ -16,9 +16,13 @@ export const highestBidsRequest = async (
   let statusCode = null
 
   try {
+    const now = Math.floor(Date.now() / 1000)
+    const maxEnd = now + 60 * 60 * 24 * 30 // 30 days from now
+
     const where: Auction_Filter = {
       settled: false,
-      endTime_gt: Math.floor(Date.now() / 1000),
+      endTime_gt: now,
+      endTime_lt: maxEnd, // Prevents auctions with bugged timestamps
     }
 
     // filter spam daos from L2


### PR DESCRIPTION
## Description

This PR addresses an issue in the highestBidsRequest function where auctions with bugged or extremely distant endTime values (e.g., thousands of hours from now) were incorrectly included in the response and displayed on the nouns.build Home Page.

✅ What was changed:
Added a 30-day upper bound to the endTime filter

## Motivation & context

Some auctions were returning corrupted or unrealistic endTime values, which led to:
- Display bugs like Ends in 232404h
- Irrelevant data being shown to users
- Restricting endTime to within 30 days ensures only timely, relevant auctions are displayed.

## Code review

Before (bugged timestamps):
![image](https://github.com/user-attachments/assets/14dd3589-dfc0-405e-b2d8-df16ad774e45)

After (filtered correctly):
![image](https://github.com/user-attachments/assets/b817478d-c2a7-4344-8dce-7d87c05bd73d)

**PS: The 3rd image is not loading due zora api stack image error.**
An image fallback was not added at this PR cause I could not confirm the correct image using OpenSea.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [X] I have done a self-review of my own code
- [X] Any new and existing tests pass locally with my changes
- [X] My changes generate no new warnings (lint warnings, console warnings, etc)
