### PR TITLE
Fix: Add fallback to nouns.build image renderer if api.zora.co fails

### DIFF
--- a/packages/ipfs-service/src/gateway.ts
+++ b/packages/ipfs-service/src/gateway.ts
@@ -14,7 +14,9 @@ export function ipfsGatewayUrls(url: string | null | undefined): string[] | unde
   if (!url || typeof url !== 'string') return undefined
   const normalizedIPFSUrl = normalizeIPFSUrl(url)
   if (normalizedIPFSUrl) {
-    return IPFS_GATEWAYS.map(gateway => normalizedIPFSUrl.replace('ipfs://', `${gateway}/ipfs/`))
+    return IPFS_GATEWAYS.map((gateway) =>
+      normalizedIPFSUrl.replace('ipfs://', `${gateway}/ipfs/`),
+    )
   }
   return undefined
 }
@@ -26,10 +28,20 @@ export function getFetchableUrls(uri: string | null | undefined): string[] | und
     // Return the gateway URL
     return ipfsGatewayUrls(uri)
   }
-  // If it is already a url (or blob or data-uri)
-  if (/^(https|data|blob):/.test(uri)) {
+
+  // If it is already a blob or data-uri
+  if (/^(data:|blob:)/.test(uri)) {
     // Return the URI
     return [uri]
+  }
+
+  // If it is a http(s) URL
+  if (/^https?:\/\//.test(uri)) {
+    const replaced = uri.replace(
+      'api.zora.co/renderer/stack-images',
+      'nouns.build/api/renderer/stack-images',
+    )
+    return [replaced]
   }
   return undefined
 }


### PR DESCRIPTION
## Description

This PR improves the image loading experience for DAOs by gracefully handling errors from the Zora image renderer and attempting a fallback using the Nouns Builder endpoint.

## Motivation & context

Some DAO Images was not loading on Home Page which resulted in a poor visual experience on the frontend. 

## Code review

Updated the <Image /> component at apps/web/src/modules/dao/components/DaoCard/DaoCard.tsx to:

- Detect when tokenImage from api.zora.co fails.
- Automatically switch to nouns.build/api/renderer/stack-images as a fallback.
- If both sources fail, default to /ImageError.svg.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [X] I have done a self-review of my own code
- [X] Any new and existing tests pass locally with my changes
- [X] My changes generate no new warnings (lint warnings, console warnings, etc)
