### PR TITLE
feat: use legacy upload directory

### DIFF
--- a/packages/ipfs-service/src/upload.ts
+++ b/packages/ipfs-service/src/upload.ts
@@ -355,7 +355,7 @@ export async function uploadDirectory(
 
   const response = await uploadWithProgress(data, 'directory', {
     onProgress: progressCallback,
-    // useLegacy: true,
+    useLegacy: true,
   })
 
   const uri = `ipfs://${response.cid}`


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored use of the legacy upload flow for directory uploads, ensuring compatibility with the legacy Pinata API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->