### PR TITLE
fix: workaround for zora subgraphs callHandlers failure

### DIFF
--- a/apps/subgraph/config/zora-mainnet.json
+++ b/apps/subgraph/config/zora-mainnet.json
@@ -4,5 +4,5 @@
     "address": "0x3ac0E64Fe2931f8e082C6Bb29283540DE9b5371C",
     "startBlock": 1778012
   },
-  "callHandlers": true
+  "callHandlers": false
 }

--- a/apps/subgraph/config/zora-sepolia.json
+++ b/apps/subgraph/config/zora-sepolia.json
@@ -4,5 +4,5 @@
     "address": "0x550c326d688fd51ae65ac6a2d48749e631023a03",
     "startBlock": 3508780
   },
-  "callHandlers": true
+  "callHandlers": false
 }

--- a/apps/subgraph/src/metadata.ts
+++ b/apps/subgraph/src/metadata.ts
@@ -9,6 +9,7 @@ import {
   WebsiteURIUpdated as URIUpdatedEvent,
 } from '../generated/templates/MetadataRendererBase/MetadataRendererBase'
 import {
+  PropertyAdded as PropertyAddedEvent,
   AddPropertiesCall as AddPropertiesFunctionCall,
   DeleteAndRecreatePropertiesCall as DeleteAndRecreatePropertiesFunctionCall,
 } from '../generated/templates/MetadataRendererV1/MetadataRendererV1'
@@ -168,6 +169,12 @@ export function handleDeleteAndRecreateProperties(
   dao.metadataProperties = properties
   dao.save()
 
+  refetchAllTokenMetadata()
+}
+
+// TODO: This is a hack or workaround to refetch all token metadata after a property is added when callHandlers are disabled.
+//       This should be removed if callHandlers work for zora-sepolia and zora-mainnet. Currently, the subgraph doesn't sync and it fails to deploy on Goldsky.
+export function handlePropertyAdded(_event: PropertyAddedEvent): void {
   refetchAllTokenMetadata()
 }
 

--- a/apps/subgraph/subgraph.yaml.mustache
+++ b/apps/subgraph/subgraph.yaml.mustache
@@ -114,6 +114,10 @@ templates:
           handler: handleDescriptionUpdated
         - event: WebsiteURIUpdated(string,string)
           handler: handleWebsiteURIUpdated
+      {{!#callHandlers}}
+        - event: PropertyAdded(uint256,string)
+          handler: handlePropertyAdded
+      {{!/callHandlers}}
       {{#callHandlers}}
       callHandlers:
         - function: addProperties(string[],(uint256,string,bool)[],(string,string))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for handling the "PropertyAdded" event to enable automatic metadata refresh when a new property is added.

* **Chores**
  * Updated configuration for Zora mainnet and Zora sepolia networks to disable call handlers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->