### PR TITLE
fix: consistent usage of wei value for proposal transactions

### DIFF
--- a/apps/web/src/modules/create-proposal/components/TransactionForm/CustomTransaction/forms/Value/Value.tsx
+++ b/apps/web/src/modules/create-proposal/components/TransactionForm/CustomTransaction/forms/Value/Value.tsx
@@ -1,6 +1,7 @@
 import { Flex } from '@buildeross/zord'
 import React from 'react'
 import { useCustomTransactionStore } from 'src/modules/create-proposal'
+import { formatEther, parseEther } from 'viem'
 
 import { CustomTransactionForm } from '../CustomTransactionForm'
 import { transactionValueFields, validateTransactionValue } from './fields'
@@ -8,14 +9,21 @@ import { transactionValueFields, validateTransactionValue } from './fields'
 export const Value = () => {
   const { customTransaction, composeCustomTransaction } = useCustomTransactionStore()
   const initialValues = {
-    transactionValue: customTransaction?.value || '',
+    transactionValue: customTransaction?.value
+      ? customTransaction.value === ''
+        ? ''
+        : formatEther(BigInt(customTransaction.value))
+      : '',
   }
 
   const submitCallback = React.useCallback(
     (values: { transactionValue: string }) => {
+      const weiValue = values.transactionValue
+        ? parseEther(values.transactionValue).toString()
+        : ''
       composeCustomTransaction({
         ...customTransaction,
-        value: values.transactionValue,
+        value: weiValue,
       })
     },
     [customTransaction, composeCustomTransaction]

--- a/apps/web/src/modules/create-proposal/components/TransactionForm/Droposal/Droposal.tsx
+++ b/apps/web/src/modules/create-proposal/components/TransactionForm/Droposal/Droposal.tsx
@@ -80,7 +80,7 @@ export const Droposal: React.FC = () => {
           imageUri,
         ],
       }),
-      value: '',
+      value: '0',
     }
 
     addTransaction({

--- a/apps/web/src/modules/create-proposal/components/TransactionForm/Escrow/Escrow.tsx
+++ b/apps/web/src/modules/create-proposal/components/TransactionForm/Escrow/Escrow.tsx
@@ -14,7 +14,7 @@ import { useProposalStore } from 'src/modules/create-proposal/stores'
 import { useChainStore } from 'src/stores/useChainStore'
 import { useDaoStore } from 'src/stores/useDaoStore'
 import useSWR from 'swr'
-import { encodeFunctionData, formatEther } from 'viem'
+import { encodeFunctionData, formatEther, parseEther } from 'viem'
 
 import EscrowForm from './EscrowForm'
 import { EscrowFormValues } from './EscrowForm.schema'
@@ -126,8 +126,10 @@ export const Escrow: React.FC = () => {
 
       // create bundler transaction data
       const escrowData = encodeEscrowData(values, treasury, cid, chain.id)
-      const milestoneAmounts = values.milestones.map((x) => x.amount * 10 ** 18)
-      const fundAmount = milestoneAmounts.reduce((acc, x) => acc + x, 0)
+      const milestoneAmounts = values.milestones.map((x) =>
+        parseEther(x.amount.toString())
+      )
+      const fundAmount = milestoneAmounts.reduce((acc, x) => acc + x, 0n)
 
       const escrow = {
         target: getEscrowBundler(chain.id),
@@ -143,15 +145,13 @@ export const Escrow: React.FC = () => {
             fundAmount,
           ],
         }),
-        value: formatEther(BigInt(fundAmount)),
+        value: fundAmount.toString(),
       }
 
       try {
         addTransaction({
           type: TransactionType.ESCROW,
-          summary: `Create and fund new Escrow with ${formatEther(
-            BigInt(fundAmount)
-          )} ETH`,
+          summary: `Create and fund new Escrow with ${formatEther(fundAmount)} ETH`,
           transactions: [escrow],
         })
       } catch (err) {

--- a/apps/web/src/modules/create-proposal/components/TransactionForm/Migration/BridgeTreasuryForm.tsx
+++ b/apps/web/src/modules/create-proposal/components/TransactionForm/Migration/BridgeTreasuryForm.tsx
@@ -11,7 +11,7 @@ import Input from 'src/components/Input/Input'
 import { TransactionType, useProposalStore } from 'src/modules/create-proposal'
 import { useChainStore } from 'src/stores/useChainStore'
 import { useDaoStore } from 'src/stores/useDaoStore'
-import { encodeFunctionData } from 'viem'
+import { encodeFunctionData, parseEther } from 'viem'
 import { useBalance } from 'wagmi'
 
 import bridgeTreasuryFormSchema, {
@@ -40,7 +40,7 @@ export const BridgeTreasuryForm = ({
   ) => {
     if (!values.amount || !migratedToChainId) return
 
-    const value = values.amount.toString()
+    const value = parseEther(values.amount.toString()).toString()
 
     const depositParams = encodeFunctionData({
       abi: l2DeployerAbi,
@@ -49,7 +49,7 @@ export const BridgeTreasuryForm = ({
 
     addTransaction({
       type: TransactionType.MIGRATION,
-      summary: `Bridge ${value} ETH to L2 DAO`,
+      summary: `Bridge ${values.amount.toString()} ETH to L2 DAO`,
       transactions: [
         {
           functionSignature: 'depositToTreasury()',

--- a/apps/web/src/modules/create-proposal/components/TransactionForm/Migration/Migration.tsx
+++ b/apps/web/src/modules/create-proposal/components/TransactionForm/Migration/Migration.tsx
@@ -9,7 +9,7 @@ import { useDaoStore } from 'src/stores/useDaoStore'
 import useSWR from 'swr'
 import { useReadContract } from 'wagmi'
 
-import { BridgeTreasuryForm } from './BirdgeTreasuryForm'
+import { BridgeTreasuryForm } from './BridgeTreasuryForm'
 import { MigrateDAOForm } from './MigrateDAOForm'
 import { MigrationTracker } from './MigrationTracker'
 import { PauseAuctionsForm } from './PauseAuctionsForm'

--- a/apps/web/src/modules/create-proposal/components/TransactionForm/SendEth/SendEth.tsx
+++ b/apps/web/src/modules/create-proposal/components/TransactionForm/SendEth/SendEth.tsx
@@ -10,7 +10,7 @@ import { NUMBER, TEXT } from 'src/components/Fields/types'
 import { TransactionType, useProposalStore } from 'src/modules/create-proposal'
 import { useChainStore } from 'src/stores/useChainStore'
 import { useDaoStore } from 'src/stores/useDaoStore'
-import { formatEther, getAddress } from 'viem'
+import { formatEther, getAddress, parseEther } from 'viem'
 import { useBalance } from 'wagmi'
 
 import sendEthSchema, { SendEthValues } from './SendEth.schema'
@@ -38,11 +38,11 @@ export const SendEth = () => {
       chain.id === CHAIN_ID.FOUNDRY ? CHAIN_ID.FOUNDRY : CHAIN_ID.ETHEREUM
 
     const target = await getEnsAddress(values.recipientAddress, getProvider(chainToQuery))
-    const value = values.amount.toString()
+    const value = parseEther(values.amount.toString()).toString()
 
     addTransaction({
       type: TransactionType.SEND_ETH,
-      summary: `Send ${value} ETH to ${walletSnippet(target)}`,
+      summary: `Send ${values.amount.toString()} ETH to ${walletSnippet(target)}`,
       transactions: [
         {
           functionSignature: 'sendEth(address)',

--- a/apps/web/src/modules/create-proposal/utils/prepareTransactions.ts
+++ b/apps/web/src/modules/create-proposal/utils/prepareTransactions.ts
@@ -1,5 +1,5 @@
 import { AddressType } from '@buildeross/types'
-import { parseEther } from 'viem'
+import { hexToBigInt } from 'viem'
 
 import { BuilderTransaction } from '../stores/useProposalStore'
 
@@ -19,7 +19,10 @@ export const prepareProposalTransactions = (
   const values = flattenedTransactions.map((txn) => {
     const value = !txn.value ? '0' : txn.value
 
-    return parseEther(value.toString())
+    if (value.startsWith('0x')) {
+      return hexToBigInt(value as `0x${string}`)
+    }
+    return BigInt(value)
   })
 
   return { calldata, targets, values }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - Corrected ETH amount handling: inputs are shown in ETH but stored and sent in wei.
  - Ensured createEdition transactions explicitly include a 0 wei value.
  - Fixed a module import name causing potential load issues.

- Refactor
  - Standardized value conversions across transaction forms using BigInt/wei.
  - Improved transaction preparation to support both hex-encoded and decimal values.
  - Updated summaries to display human-readable ETH while preserving precise on-chain values.

- Chores
  - Minor dependency/import adjustments for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->