### PR TITLE
feat: update etherscan links to profile links for bids

### DIFF
--- a/apps/web/src/modules/auction/components/AllBids/BidCard.tsx
+++ b/apps/web/src/modules/auction/components/AllBids/BidCard.tsx
@@ -1,4 +1,3 @@
-import { ETHERSCAN_BASE_URL } from '@buildeross/constants/etherscan'
 import { useEnsData } from '@buildeross/hooks/useEnsData'
 import { AuctionBidFragment } from '@buildeross/sdk/subgraph'
 import { formatCryptoVal } from '@buildeross/utils/numbers'
@@ -6,11 +5,9 @@ import { Box, Flex, Text } from '@buildeross/zord'
 import React from 'react'
 import { Avatar } from 'src/components/Avatar'
 import { Icon } from 'src/components/Icon'
-import { useChainStore } from 'src/stores/useChainStore'
 
 export const BidCard = ({ bid }: { bid: AuctionBidFragment }) => {
   const { displayName, ensAvatar } = useEnsData(bid?.bidder)
-  const chain = useChainStore((x) => x.chain)
 
   return (
     <Flex direction={'column'} my="x4" align="center" style={{ height: 35 }}>
@@ -24,7 +21,7 @@ export const BidCard = ({ bid }: { bid: AuctionBidFragment }) => {
         <Flex direction="row" align="center">
           <Flex
             as="a"
-            href={`${ETHERSCAN_BASE_URL[chain.id]}/address/${bid.bidder}`}
+            href={`/profile/${bid.bidder}`}
             target="_blank"
             rel="noopener noreferrer"
           >

--- a/apps/web/src/modules/auction/components/CurrentAuction/Bidder.tsx
+++ b/apps/web/src/modules/auction/components/CurrentAuction/Bidder.tsx
@@ -1,6 +1,5 @@
 import { useEnsData } from '@buildeross/hooks/useEnsData'
 import { Box, Flex, Text } from '@buildeross/zord'
-import Link from 'next/link'
 import React from 'react'
 import { Avatar } from 'src/components/Avatar'
 
@@ -19,9 +18,9 @@ export const Bidder: React.FC<BidderProps> = ({ address }) => {
         <Avatar address={address} src={ensAvatar} size="32" />
       </Box>
       <Text className={recentBidder} variant="paragraph-md">
-        <Link href={`/profile/${address}`} passHref>
-          <a>{displayName}</a>
-        </Link>
+        <a href={`/profile/${address}`} target="_blank" rel="noopener noreferrer">
+          {displayName}
+        </a>
       </Text>
     </Flex>
   )

--- a/apps/web/src/modules/auction/components/CurrentAuction/RecentBids.tsx
+++ b/apps/web/src/modules/auction/components/CurrentAuction/RecentBids.tsx
@@ -1,10 +1,8 @@
-import { ETHERSCAN_BASE_URL } from '@buildeross/constants/etherscan'
 import { AuctionBidFragment } from '@buildeross/sdk/subgraph'
 import { Box, Flex, Stack, Text } from '@buildeross/zord'
 import dynamic from 'next/dynamic'
 import React from 'react'
 import { Icon } from 'src/components/Icon'
-import { useChainStore } from 'src/stores/useChainStore'
 
 import { AllBids } from '../AllBids'
 import { allRecentBidsButton, recentBid } from '../Auction.css'
@@ -19,8 +17,6 @@ interface RecentBidsProps {
 }
 
 export const RecentBids: React.FC<RecentBidsProps> = ({ bids }) => {
-  const chain = useChainStore((x) => x.chain)
-
   return bids.length ? (
     <Box mt="x3">
       <Stack>
@@ -37,7 +33,7 @@ export const RecentBids: React.FC<RecentBidsProps> = ({ bids }) => {
             <Flex
               align="center"
               as="a"
-              href={`${ETHERSCAN_BASE_URL[chain.id]}/address/${bidder}`}
+              href={`/profile/${bidder}`}
               target="_blank"
               rel="noopener noreferrer"
             >

--- a/apps/web/src/modules/auction/components/WinningBidder.tsx
+++ b/apps/web/src/modules/auction/components/WinningBidder.tsx
@@ -1,16 +1,13 @@
 import { NULL_ADDRESS } from '@buildeross/constants/addresses'
-import { ETHERSCAN_BASE_URL } from '@buildeross/constants/etherscan'
 import { useEnsData } from '@buildeross/hooks/useEnsData'
 import { Box, Flex } from '@buildeross/zord'
 import { Avatar } from 'src/components/Avatar'
 import { Icon } from 'src/components/Icon'
-import { useChainStore } from 'src/stores/useChainStore'
 
 import { AuctionDetail } from './AuctionDetail'
 
 export const WinningBidder = ({ owner }: { owner?: string }) => {
   const { displayName, ensAvatar } = useEnsData(owner)
-  const chain = useChainStore((x) => x.chain)
 
   return (
     <AuctionDetail title="Held by">
@@ -21,7 +18,7 @@ export const WinningBidder = ({ owner }: { owner?: string }) => {
           <Avatar address={owner} src={ensAvatar} size={'24'} />
           <Box
             as="a"
-            href={`${ETHERSCAN_BASE_URL[chain.id]}/address/${owner}`}
+            href={`/profile/${owner}`}
             rel={'noopener noreferrer'}
             target="_blank"
             ml={'x2'}

--- a/apps/web/src/modules/dao/components/About/Founder.tsx
+++ b/apps/web/src/modules/dao/components/About/Founder.tsx
@@ -1,11 +1,9 @@
-import { ETHERSCAN_BASE_URL } from '@buildeross/constants/etherscan'
 import { useEnsData } from '@buildeross/hooks'
 import { AddressType } from '@buildeross/types'
 import { Box, Flex, PopUp, Text } from '@buildeross/zord'
 import { useState } from 'react'
 import { Avatar } from 'src/components/Avatar'
 import { Icon } from 'src/components/Icon'
-import { useChainStore } from 'src/stores/useChainStore'
 
 interface FounderProps {
   wallet: AddressType
@@ -15,7 +13,6 @@ interface FounderProps {
 
 export const Founder: React.FC<FounderProps> = ({ wallet, ownershipPct, vestExpiry }) => {
   const [showTooltip, setShowTooltip] = useState(false)
-  const chain = useChainStore((x) => x.chain)
   const { displayName, ensAvatar } = useEnsData(wallet as string)
   const vestDate = new Date(vestExpiry * 1000).toLocaleDateString(undefined, {
     year: 'numeric',
@@ -42,7 +39,7 @@ export const Founder: React.FC<FounderProps> = ({ wallet, ownershipPct, vestExpi
             as="a"
             target="_blank"
             rel="noreferrer noopener"
-            href={`${ETHERSCAN_BASE_URL[chain.id]}/address/${wallet}`}
+            href={`/profile/${wallet}`}
             fontWeight={'display'}
           >
             {displayName}

--- a/apps/web/src/modules/dao/components/Activity/CurrentDelegate.tsx
+++ b/apps/web/src/modules/dao/components/Activity/CurrentDelegate.tsx
@@ -1,12 +1,10 @@
-import { ETHERSCAN_BASE_URL } from '@buildeross/constants/etherscan'
 import { type DaoMembership } from '@buildeross/hooks/useDaoMembership'
 import { walletSnippet } from '@buildeross/utils/helpers'
 import { Box, Button, Flex } from '@buildeross/zord'
 import React from 'react'
 import { Avatar } from 'src/components/Avatar'
-import { Icon } from 'src/components/Icon'
-import { useChainStore } from 'src/stores/useChainStore'
-import { proposalFormTitle } from 'src/styles/Proposals.css'
+import CopyButton from 'src/components/CopyButton/CopyButton'
+import { currentDelegateBtn, proposalFormTitle } from 'src/styles/Proposals.css'
 
 interface CurrentDelegateProps {
   toggleIsEditing: () => void
@@ -17,8 +15,6 @@ export const CurrentDelegate = ({
   toggleIsEditing,
   membership,
 }: CurrentDelegateProps) => {
-  const chain = useChainStore((x) => x.chain)
-
   return (
     <Flex direction={'column'} width={'100%'}>
       <Box className={proposalFormTitle} fontSize={28} mb={'x4'}>
@@ -31,16 +27,28 @@ export const CurrentDelegate = ({
 
       <Box mb={'x2'}>Current delegate</Box>
 
-      <Box>
+      <Flex
+        align={'center'}
+        height={'x16'}
+        mb={'x6'}
+        borderColor="border"
+        borderWidth="normal"
+        borderStyle="solid"
+        borderRadius="curved"
+        gap={'x4'}
+        pr={'x4'}
+      >
         <Flex
+          as="a"
+          target="_blank"
+          rel="noreferrer noopener"
+          href={`/profile/${membership.delegate.ethAddress}`}
           align={'center'}
-          height={'x16'}
-          mb={'x6'}
           px={'x6'}
-          borderColor="border"
-          borderWidth="normal"
-          borderStyle="solid"
-          borderRadius="curved"
+          height="100%"
+          flex={1}
+          className={currentDelegateBtn}
+          style={{ cursor: 'pointer' }}
         >
           <Box mr={'x2'}>
             {membership.delegate.ensAvatar ? (
@@ -65,22 +73,14 @@ export const CurrentDelegate = ({
           ) : (
             <Box mr="auto">{walletSnippet(membership.delegate.ethAddress)}</Box>
           )}
-
-          <Box
-            as="a"
-            ml={'x3'}
-            href={`${ETHERSCAN_BASE_URL[chain.id]}/address/${membership.delegate.ethAddress}`}
-            target="_blank"
-          >
-            <Icon size="sm" id="external-16" fill="text4" />
-          </Box>
         </Flex>
+        <CopyButton text={membership.delegate.ethAddress} />
+      </Flex>
 
-        <Box>
-          <Button width={'100%'} onClick={toggleIsEditing} size="lg">
-            Update delegate
-          </Button>
-        </Box>
+      <Box>
+        <Button width={'100%'} onClick={toggleIsEditing} size="lg">
+          Update delegate
+        </Button>
       </Box>
     </Flex>
   )

--- a/apps/web/src/styles/Proposals.css.ts
+++ b/apps/web/src/styles/Proposals.css.ts
@@ -23,6 +23,13 @@ export const delegateBtn = style({
   },
 })
 
+export const currentDelegateBtn = style({
+  backgroundColor: '#FFF !important',
+  ':hover': {
+    backgroundColor: '#F9F9F9 !important',
+  },
+})
+
 export const createProposalBtn = style({
   fontFamily: 'ptRoot !important',
   height: '40px !important',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - All bidder, winning bidder, founder, and recent-bid links now open internal profile pages instead of an external explorer.
  - Current Delegate row is fully clickable and opens the delegate’s profile in a new tab.
  - Added a Copy Address button for the Current Delegate.

- **Style**
  - Refreshed Current Delegate row with bordered, rounded layout and improved spacing.
  - Added a white-background button style with a subtle hover state for the Current Delegate action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->