### PR TITLE
Fix two silent dead ends in the droposal / proposal flow

### DIFF
--- a/apps/web/src/pages/dao/[network]/[token]/proposal/create.tsx
+++ b/apps/web/src/pages/dao/[network]/[token]/proposal/create.tsx
@@ -456,7 +456,15 @@ const CreateProposalPage: NextPageWithLayout = () => {
     if (!missingReviewRequirements.length) return null
 
     if (hasDraftBlockers) {
-      return `To continue, fix proposal metadata (${joinRequirements(missingDraftRequirements)}) and queue at least one transaction if needed.`
+      // Only name the queue when it is actually empty — telling someone to queue
+      // a transaction while their queue is on screen buries the real blocker.
+      const outstanding = missingReviewRequirements.filter(
+        (requirement) => !missingDraftRequirements.includes(requirement)
+      )
+      return `To continue, ${joinRequirements([
+        `fix proposal metadata (${joinRequirements(missingDraftRequirements)})`,
+        ...outstanding,
+      ])}.`
     }
 
     return `To continue, ${joinRequirements(missingReviewRequirements)}.`

--- a/apps/web/src/pages/dao/[network]/[token]/proposal/create.tsx
+++ b/apps/web/src/pages/dao/[network]/[token]/proposal/create.tsx
@@ -749,26 +749,20 @@ const CreateProposalPage: NextPageWithLayout = () => {
 
         {continueHelperText && (
           <Flex align={'center'} gap={'x2'} mb={'x4'}>
-            <Text variant={'paragraph-sm'} color={'text3'}>
+            <Text variant={'paragraph-sm'} color={'negative'}>
               {continueHelperText}
             </Text>
             {createStage === 'transactions' && hasDraftBlockers && (
               <Button
-                variant={'ghost'}
-                size={'sm'}
+                variant={'secondaryOutline'}
+                size={'xs'}
+                pill
                 onClick={() => setCreateStage('draft')}
-                style={{
-                  minHeight: 'auto',
-                  height: 'auto',
-                  padding: 0,
-                  textDecoration: 'underline',
-                }}
+                style={{ fontSize: 12 }}
               >
-                <Text variant={'paragraph-sm'} color={'text3'}>
-                  {hasTitleDraftBlocker
-                    ? 'Fix title in Write Proposal'
-                    : 'Go to Write Proposal'}
-                </Text>
+                {hasTitleDraftBlocker
+                  ? 'Fix title in Write Proposal'
+                  : 'Go to Write Proposal'}
               </Button>
             )}
           </Flex>

--- a/packages/dao-ui/src/components/Gallery/Gallery.tsx
+++ b/packages/dao-ui/src/components/Gallery/Gallery.tsx
@@ -257,18 +257,24 @@ export const Gallery: React.FC<GalleryProps> = ({
       case 'dao-post':
         startProposalDraft({
           transactionType: TransactionType.CONTENT_COIN,
+          title: 'Propose Post',
+          summary: 'Create a governance proposal to publish a post.',
         })
         onOpenProposalCreate('transactions')
         break
       case 'dao-drop':
         startProposalDraft({
           transactionType: TransactionType.DROPOSAL,
+          title: 'Propose Drop',
+          summary: 'Create a governance proposal to publish a drop.',
         })
         onOpenProposalCreate('transactions')
         break
       case 'dao-creator-coin':
         startProposalDraft({
           transactionType: TransactionType.CREATOR_COIN,
+          title: 'Propose Creator Coin',
+          summary: 'Create a governance proposal to launch the creator coin.',
         })
         onOpenProposalCreate('transactions')
         break

--- a/packages/ui/src/SingleMediaUpload/SingleMediaUpload.test.tsx
+++ b/packages/ui/src/SingleMediaUpload/SingleMediaUpload.test.tsx
@@ -1,0 +1,50 @@
+import { act, render, screen } from '@testing-library/react'
+import { Form, Formik } from 'formik'
+import React from 'react'
+import { describe, expect, it } from 'vitest'
+import * as yup from 'yup'
+
+import { SingleMediaUpload } from './SingleMediaUpload'
+
+const schema = yup.object({ mediaUrl: yup.string().required('*') })
+
+const Harness: React.FC = () => (
+  <Formik
+    initialValues={{ mediaUrl: '' }}
+    validationSchema={schema}
+    onSubmit={() => undefined}
+  >
+    {(formik) => (
+      <Form>
+        <SingleMediaUpload
+          formik={formik}
+          id="mediaUrl"
+          inputLabel="Media"
+          value={formik.values.mediaUrl}
+          helperText="Upload a file"
+        />
+        <button type="submit">Add Transaction to Queue</button>
+      </Form>
+    )}
+  </Formik>
+)
+
+describe('SingleMediaUpload', () => {
+  it('says nothing before the form is submitted', () => {
+    render(<Harness />)
+    expect(screen.queryByTestId('error-msg')).toBeNull()
+    expect(screen.getByText('Upload a file')).toBeTruthy()
+  })
+
+  it('explains the missing file once submit is attempted', async () => {
+    render(<Harness />)
+    await act(async () => {
+      screen.getByRole('button', { name: 'Add Transaction to Queue' }).click()
+    })
+
+    const error = await screen.findByTestId('error-msg')
+    // The schema's bare '*' would be meaningless on its own here.
+    expect(error.textContent).toContain('Media is required')
+    expect(screen.queryByText('Upload a file')).toBeNull()
+  })
+})

--- a/packages/ui/src/SingleMediaUpload/SingleMediaUpload.test.tsx
+++ b/packages/ui/src/SingleMediaUpload/SingleMediaUpload.test.tsx
@@ -8,6 +8,14 @@ import { SingleMediaUpload } from './SingleMediaUpload'
 
 const schema = yup.object({ mediaUrl: yup.string().required('*') })
 
+const nestedSchema = yup.object({
+  milestones: yup.array().of(
+    yup.object({
+      mediaUrl: yup.string().required('*'),
+    })
+  ),
+})
+
 const Harness: React.FC = () => (
   <Formik
     initialValues={{ mediaUrl: '' }}
@@ -21,6 +29,27 @@ const Harness: React.FC = () => (
           id="mediaUrl"
           inputLabel="Media"
           value={formik.values.mediaUrl}
+          helperText="Upload a file"
+        />
+        <button type="submit">Add Transaction to Queue</button>
+      </Form>
+    )}
+  </Formik>
+)
+
+const NestedHarness: React.FC = () => (
+  <Formik
+    initialValues={{ milestones: [{ mediaUrl: '' }] }}
+    validationSchema={nestedSchema}
+    onSubmit={() => undefined}
+  >
+    {(formik) => (
+      <Form>
+        <SingleMediaUpload
+          formik={formik}
+          id="milestones.0.mediaUrl"
+          inputLabel="Milestone media"
+          value={formik.values.milestones[0].mediaUrl}
           helperText="Upload a file"
         />
         <button type="submit">Add Transaction to Queue</button>
@@ -45,6 +74,17 @@ describe('SingleMediaUpload', () => {
     const error = await screen.findByTestId('error-msg')
     // The schema's bare '*' would be meaningless on its own here.
     expect(error.textContent).toContain('Media is required')
+    expect(screen.queryByText('Upload a file')).toBeNull()
+  })
+
+  it('shows nested field errors from formik paths', async () => {
+    render(<NestedHarness />)
+    await act(async () => {
+      screen.getByRole('button', { name: 'Add Transaction to Queue' }).click()
+    })
+
+    const error = await screen.findByTestId('error-msg')
+    expect(error.textContent).toContain('Milestone media is required')
     expect(screen.queryByText('Upload a file')).toBeNull()
   })
 })

--- a/packages/ui/src/SingleMediaUpload/SingleMediaUpload.tsx
+++ b/packages/ui/src/SingleMediaUpload/SingleMediaUpload.tsx
@@ -47,6 +47,17 @@ export const SingleMediaUpload: React.FC<SingleMediaUploadProps> = ({
     setIsMounted(true)
   }, [])
 
+  // A required field with nothing uploaded fails validation with no visible
+  // reason otherwise: submit just does nothing, since this component only ever
+  // rendered its own upload failures.
+  const rawError = formik.errors[id]
+  const validationError =
+    formik.submitCount > 0 && typeof rawError === 'string'
+      ? rawError === '*'
+        ? `${typeof inputLabel === 'string' ? inputLabel : 'This field'} is required`
+        : rawError
+      : undefined
+
   const truncate = (value: string) => {
     return value.length > 40 ? `${value.substring(0, 40)}...` : value
   }
@@ -166,14 +177,14 @@ export const SingleMediaUpload: React.FC<SingleMediaUploadProps> = ({
             handleFileUpload(event.currentTarget.files)
           }}
         />
-        {helperText && !uploadMediaError && (
+        {helperText && !uploadMediaError && !validationError && (
           <Box className={defaultHelperTextStyle}>{helperText}</Box>
         )}
 
-        {uploadMediaError && (
+        {(uploadMediaError || validationError) && (
           <Box data-testid="error-msg" p={'x4'} fontSize={12} className={uploadErrorBox}>
             <Box as={'ul'} m={'x0'}>
-              <li>{uploadMediaError.message}</li>
+              <li>{uploadMediaError?.message ?? validationError}</li>
             </Box>
           </Box>
         )}

--- a/packages/ui/src/SingleMediaUpload/SingleMediaUpload.tsx
+++ b/packages/ui/src/SingleMediaUpload/SingleMediaUpload.tsx
@@ -5,7 +5,7 @@ import {
   type UploadType,
 } from '@buildeross/ipfs-service'
 import { Box, Flex, Spinner, Stack, Text } from '@buildeross/zord'
-import { FormikProps } from 'formik'
+import { type FormikProps, getIn } from 'formik'
 import React, { ReactElement, useEffect, useMemo, useState } from 'react'
 
 import { defaultHelperTextStyle, defaultInputLabelStyle } from '../styles'
@@ -50,7 +50,7 @@ export const SingleMediaUpload: React.FC<SingleMediaUploadProps> = ({
   // A required field with nothing uploaded fails validation with no visible
   // reason otherwise: submit just does nothing, since this component only ever
   // rendered its own upload failures.
-  const rawError = formik.errors[id]
+  const rawError = getIn(formik.errors, id)
   const validationError =
     formik.submitCount > 0 && typeof rawError === 'string'
       ? rawError === '*'


### PR DESCRIPTION
Both reported by @benedictvs while testing the droposal flow after #982 merged.

### 1. Missing media blocks the form with no explanation

`mediaUrl` is required by `droposalFormSchema`, but `SingleMediaUpload` only ever rendered its *own* upload failures — never the field's validation error. With no file chosen, Formik blocks the submit and **"Add Transaction to Queue" does nothing at all**, with nothing on screen to say why.

The field error now renders once a submit has been attempted, and the schema's bare `*` is translated into something actionable ("Media is required"). Two tests cover it: silent before submit, explicit after.

This is in the shared component, so `CoinFormFields` and `MilestoneForm` get the same behaviour.

### 2. "Queue at least one transaction" — with a transaction in the queue

<img width="560" alt="the banner asks for a queued transaction while the droposal sits in the queue" src="https://github.com/user-attachments/assets/41a0a928-0fbd-4093-a57c-2bca03561d75">

Ben's screenshot shows the droposal queued and the banner reading:

> To continue, fix proposal metadata (add a proposal title and add a proposal summary) **and queue at least one transaction if needed.**

That tail was hardcoded into the draft-blocker branch of `continueHelperText`, so it appeared whether or not the queue was empty. The real blocker — an empty title and summary — was listed next to an item that was plainly already done, which is what made the greyed-out Continue read as a bug rather than as missing metadata. The queue is now named only when it is actually empty.

### Not fixed here

You can reach the **Add transactions** stage with an empty draft: the effect that reacts to `transactionType` calls `setCreateStage('transactions')` and `setFurthestStage('transactions')` without checking `canEnterStage.transactions`. That is how Ben got there with no title or summary. Changing it alters navigation, so I left it alone — @dan13ram, is that jump intentional?

Verified: eslint, `tsc --noEmit` across `@buildeross/ui`, `@buildeross/create-proposal-ui` and the web app, plus the new tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Draft proposals created from gallery options now include descriptive titles and summaries based on the selected transaction type.

- **Bug Fixes**
  - Proposal creation guidance now accurately reflects whether transactions still need to be queued, avoiding unnecessary instructions.
  - Media upload validation now displays a clear required-field message after submission when no media is provided.
  - Upload error messages are shown consistently, while general helper text is hidden when a validation error appears.
  - Proposal guidance uses clearer error styling and a more prominent action button.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->